### PR TITLE
Update CVE-2023-25136.py

### DIFF
--- a/CVE-2023-25136.py
+++ b/CVE-2023-25136.py
@@ -9,7 +9,12 @@ class SSHVulnerabilityChecker:
 
     def check_vulnerability(self, ip):
         try:
-            transport = paramiko.Transport(ip, timeout=1)
+# Consider using a socket object with a timeout value as the `sock` argument for `connect()` instead of passing a `timeout` argument directly. See the note in the `Transport` class for more information.
+
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(1)
+            sock.connect((ip, 22))
+            transport = paramiko.Transport(socket)
             transport.local_version = f"SSH-2.0-{self.client_id}"
             transport.connect(username='', password='')
             print(colored(f"{ip}: Vulnerable", 'green'))

--- a/CVE-2023-25136.py
+++ b/CVE-2023-25136.py
@@ -10,11 +10,8 @@ class SSHVulnerabilityChecker:
     def check_vulnerability(self, ip):
         try:
 # Consider using a socket object with a timeout value as the `sock` argument for `connect()` instead of passing a `timeout` argument directly. See the note in the `Transport` class for more information.
-
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.settimeout(1)
-            sock.connect((ip, 22))
-            transport = paramiko.Transport(socket)
+            transport = paramiko.Transport(ip)
+            transport.sock.settimeout(1)
             transport.local_version = f"SSH-2.0-{self.client_id}"
             transport.connect(username='', password='')
             print(colored(f"{ip}: Vulnerable", 'green'))


### PR DESCRIPTION
Added a note to the Transport class about the connect() method not accepting a timeout argument. The recommended solution is to create a socket object using the socket library and pass it as the sock argument to the connect() method.